### PR TITLE
feat: Implement directory path redirection(#19)

### DIFF
--- a/srcs/Request.hpp
+++ b/srcs/Request.hpp
@@ -20,14 +20,15 @@ private:
 	std::string							version_;
 	std::map<std::string, std::string>	headers_;
 	std::string							body_;
+	std::string							filePath_;
+	std::string							originalHeader_;
+	std::string							originalBody_;
 
 	void	parseHeader(const std::vector<std::string> &splitedMessage);
-	void	parseChunkedBody(const std::string &originalBody);
-
-	Request();
+	void	parseChunkedBody();
 
 public:
-	Request(const std::string &header);
+	Request();
 	~Request();
 
 	const std::string							&getMethod();
@@ -36,9 +37,20 @@ public:
 	const std::map<std::string, std::string>	&getHeaders();
 	const std::string							getHeaderValue(std::string fieldName);
 	const std::string							&getBody();
+	const std::string							&getFilePath();
+	const std::string							&getOriginalHeader();
+	const std::string							&getOriginalBody();
 
-	void	setBody(std::string &body);
-	void	appendHeader(std::string fieldName, std::string value);
+	std::size_t	getContentLengthNumber();
+	
+	void	setBody();
+	void	setHeaders();
+	void	setFilePath(const std::string &webRoot);
+	void	setOriginalHeader(const std::string &originalHeader);
+	void	setOriginalBody(const std::string &originalBody);
+
+	void	appendOriginalHeader(const std::string &buf);
+	void	appendOriginalBody(const std::string &buf);
 };
 
 #endif

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -29,3 +29,7 @@ std::string	Response::createMessage() {
 	message += body_;
 	return message;
 }
+
+void	Response::appendHeader(std::string fieldName, std::string value) {
+	headers_.insert(std::pair<std::string, std::string>(fieldName, value));
+}

--- a/srcs/Response.hpp
+++ b/srcs/Response.hpp
@@ -26,6 +26,7 @@ public:
 	Response(std::string status, std::string body);
 	~Response();
 	std::string	createMessage();
+	void	appendHeader(std::string fieldName, std::string value);
 };
 
 #endif

--- a/srcs/Uri.cpp
+++ b/srcs/Uri.cpp
@@ -45,11 +45,11 @@ Uri::Uri(const std::string &originalUri) {
 	uriDir_ = tmp;
 	dir_ = uriDir_;
 
-	// std::cout << "[Uri Class]" << std::endl;
-	// std::cout << "uriDir: " << uriDir_ << std::endl;
-	// std::cout << "basename_: " << basename_ << std::endl;
-	// std::cout << "pathInfo_: " << pathInfo_ << std::endl;
-	// std::cout << "queryString_: " << queryString_ << std::endl << std::endl;
+	std::cout << "[Uri Class]" << std::endl;
+	std::cout << "uriDir: " << uriDir_ << std::endl;
+	std::cout << "basename_: " << basename_ << std::endl;
+	std::cout << "pathInfo_: " << pathInfo_ << std::endl;
+	std::cout << "queryString_: " << queryString_ << std::endl << std::endl;
 }
 
 Uri::~Uri() {}

--- a/srcs/Uri.hpp
+++ b/srcs/Uri.hpp
@@ -13,7 +13,7 @@ class Uri {
 private:
 	std::string originalUri_;
 	std::string	uriDir_;
-	std::string	dir_;
+	std::string	dir_;	// 실제 디렉토리 (redirect 설정이 있는 경우 uriDir와 다른 값)
 	std::string	basename_;
 	std::string	pathInfo_;
 	std::string	queryString_;

--- a/srcs/Worker.cpp
+++ b/srcs/Worker.cpp
@@ -230,7 +230,7 @@ ft_bool Worker::executeGet() {
 
 	filePath = request_->getFilePath();
 	if (isDirectory(filePath) && request_->getUri()->getBaseName().length() > 0) {
-		redirect("http://" + request_->getHeaderValue("host") + request_->getUri()->getOriginalUri() + "/");
+		redirect(request_->getUri()->getOriginalUri() + "/");
 		return FT_TRUE;
 	}
 	if (isDirectory(filePath))

--- a/srcs/Worker.hpp
+++ b/srcs/Worker.hpp
@@ -28,9 +28,6 @@ private:
 	int							connectSocket_;
 	struct pollfd				*pollfd_;
 	Request						*request_;
-	std::string					filePath_;
-	std::string					originalHeader_;
-	std::string					originalBody_;
 	ft_bool						isHeaderSet_;
 	ft_bool						isRecvCompleted_;
 
@@ -41,6 +38,9 @@ private:
 	ft_bool	executeGet();
 	ft_bool	executePost();
 	ft_bool	executeDelete();
+	void	redirect(const std::string &des);
+
+	Worker();
 
 public:
 	Worker(int listenSocket);

--- a/srcs/macro.hpp
+++ b/srcs/macro.hpp
@@ -19,6 +19,7 @@
 #define	HTTP_OK						"200 OK"
 #define HTTP_CREATED				"201 CREATED"
 #define HTTP_NO_CONTENT				"204 No Content"
+#define HTTP_MOVED_PERMANENTLY		"301 Moved Permanently"
 #define HTTP_BAD_REQUEST			"400 Bad Request"
 #define HTTP_FORBIDDEN				"403 Forbidden"
 #define HTTP_NOT_FOUND				"404 Not Found"


### PR DESCRIPTION
## 작업 내용
- closes #19

## 리뷰어에게
- 원칙적으로 각 요청과 응답은 독립적이어야 합니다. 그러나 각 요청에서 독립적인 filePath, OriginalHeader, OriginalBody를 Worker에서 관리함으로서 이전에 처리했던 요청의 흔적이 남아있게 되어 요청을 계속 보내도 첫 번째 요청에 대한 응답을 보내는 오동작이 발생하고 있었습니다.
  👉 위의 Worker 멤버 변수를 Request로 옮겨서 구조를 개편하였습니다.