### PR TITLE
Fix CRLF issue when response binary file

### DIFF
--- a/srcs/Cgi.cpp
+++ b/srcs/Cgi.cpp
@@ -118,11 +118,7 @@ std::string	Cgi::execute() {
 	/* if POST method, write request body to child process */
 	if (request_->getMethod() == "POST") {
 		std::vector<char> body = request_->getBody();
-		std::vector<char>::iterator it = body.begin();
-		while (it != body.end()) {
-			write(writePipe[FT_PIPEIN], &(*it), 1);
-			it++;
-		}
+		write(writePipe[FT_PIPEIN], reinterpret_cast<char*> (&body[0]), body.size());
 	}
 	close(writePipe[FT_PIPEIN]);
 

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -6,7 +6,7 @@ Response::Response(std::string status) {
 	makeDefaultHeaders();
 }
 
-Response::Response(std::string status, const std::vector<char> &result) {
+Response::Response(std::string status, const std::vector<char> &result, ft_bool isCgi) {
 	statusCode_ = std::atoi(status.substr(0, 3).c_str());
 	statusLine_ = "HTTP/1.1 " + status;
 
@@ -18,20 +18,21 @@ Response::Response(std::string status, const std::vector<char> &result) {
 	std::vector<std::string>			splitedHeaderLine;
 	std::vector<std::string>::iterator	it_s;
 
-	it = std::search(result.begin(), result.end(), crlf, crlf + strlen(crlf));
-	if (it != result.end()) {
-		body_ = std::vector<char>(it + strlen(crlf), result.end());
-		cgiHeaders = std::string(result.begin(), it);
-		std::cout << "cgiHeaders: " << cgiHeaders << std::endl;
-		splitedHeaders = split(std::string(cgiHeaders.begin(), cgiHeaders.end()), "\n");
-		
-		for (it_s = splitedHeaders.begin(); it_s != splitedHeaders.end(); it_s++) {
-			splitedHeaderLine = split(*it_s, ": ");
-			std::transform(splitedHeaderLine[0].begin(), splitedHeaderLine[0].end(), splitedHeaderLine[0].begin(), ::tolower);
-			appendHeader(splitedHeaderLine[0], splitedHeaderLine[1]);
+	body_ = result;
+	if (isCgi) {
+		it = std::search(result.begin(), result.end(), crlf, crlf + strlen(crlf));
+		if (it != result.end()) {
+			body_ = std::vector<char>(it + strlen(crlf), result.end());
+			cgiHeaders = std::string(result.begin(), it);
+			std::cout << "cgiHeaders: " << cgiHeaders << std::endl;
+			splitedHeaders = split(std::string(cgiHeaders.begin(), cgiHeaders.end()), "\n");
+
+			for (it_s = splitedHeaders.begin(); it_s != splitedHeaders.end(); it_s++) {
+				splitedHeaderLine = split(*it_s, ": ");
+				std::transform(splitedHeaderLine[0].begin(), splitedHeaderLine[0].end(), splitedHeaderLine[0].begin(), ::tolower);
+				appendHeader(splitedHeaderLine[0], splitedHeaderLine[1]);
+			}
 		}
-	} else {
-		body_ = result;
 	}
 	makeDefaultHeaders();
 }
@@ -86,13 +87,13 @@ std::vector<char>	Response::createMessage() {
 
 void	Response::setContentType(std::string fileExtension) {
 	headers_.erase("content-type");
-	if (fileExtension == "html") 
+	if (fileExtension == "html")
 		appendHeader("content-type", MIME_HTML);
 	else if (fileExtension == "css")
 		appendHeader("content-type", MIME_CSS);
 	else if (fileExtension == "gif")
 		appendHeader("content-type", MIME_IMAGE_GIF);
-	else if (fileExtension == "jpeg" || fileExtension == "jpg") 
+	else if (fileExtension == "jpeg" || fileExtension == "jpg")
 		appendHeader("content-type", MIME_IMAGE_JPG);
 	else if (fileExtension == "js")
 		appendHeader("content-type", MIME_APP_JS);

--- a/srcs/Response.hpp
+++ b/srcs/Response.hpp
@@ -28,7 +28,7 @@ private:
 
 public:
 	Response(std::string status);
-	Response(std::string status, const std::vector<char> &result);
+	Response(std::string status, const std::vector<char> &result, ft_bool isCgi = false);
 	~Response();
 
 	std::vector<char>	createMessage();

--- a/srcs/Worker.cpp
+++ b/srcs/Worker.cpp
@@ -245,7 +245,7 @@ ft_bool Worker::executeGet() {
 		Cgi cgi(request_);
 		std::string result = cgi.execute();
 
-		Response response(HTTP_OK, stringToCharV(result));
+		Response response(HTTP_OK, stringToCharV(result), FT_TRUE);
 		send(response.createMessage());
 		return FT_TRUE;
 	}
@@ -265,7 +265,7 @@ ft_bool Worker::executePost() {
 	if (isCgi(request_->getFilePath())) {
 		Cgi cgi(request_);
 		std::string result = cgi.execute();
-		Response response(HTTP_CREATED, stringToCharV(result));
+		Response response(HTTP_CREATED, stringToCharV(result), FT_TRUE);
 		send(response.createMessage());
 	}
 	return FT_TRUE;


### PR DESCRIPTION
## 작업 내용
- closes #49

## 리뷰어에게
- 오류가 발생하던 이미지도 잘 GET 해옵니다.
- 추가로 CGI로 body를 보낼 때 char vector의 내용을 반복문 안에서 1바이트씩 write 하던 부분을, casting을 사용하여 라인을 줄였습니다.
- 용량이 큰 이미지 업로드 테스트를 하면서 Worker 클래스의 BUFFER_LENGTH 사이즈가 업로드 속도에 영향을 준다는 것을 알아냈습니다.