### PR TITLE
perf: Improve speed(#64)

### DIFF
--- a/srcs/Cgi.cpp
+++ b/srcs/Cgi.cpp
@@ -71,14 +71,15 @@ char **Cgi::getEnv() {
 	return charEnv;
 }
 
-std::string Cgi::execute() {
-	pid_t		pid;
-	int			tmpStd[2];
-	long		fileFds[2];
-	std::string	result;
-	int			ret = 1;
-	std::vector<char> body = request_->getBody();
-	char		readBuf[CGI_BUF_SIZE];
+const std::vector<char> &Cgi::execute() {
+	timestampNoSocket("cgi execute start", start);
+	pid_t				pid;
+	int					tmpStd[2];
+	long				fileFds[2];
+	std::string			tmpResult;
+	int					ret = 1;
+	std::vector<char>	body = request_->getBody();
+	char				readBuf[CGI_BUF_SIZE];
 
 	tmpStd[STDIN_FILENO] = dup(STDIN_FILENO);
 	tmpStd[STDOUT_FILENO] = dup(STDOUT_FILENO);
@@ -88,16 +89,20 @@ std::string Cgi::execute() {
 	fileFds[STDIN_FILENO] = fileno(tmpFileIn);
 	fileFds[STDOUT_FILENO] = fileno(tmpFileOut);
 
+	fcntl(fileFds[STDIN_FILENO], F_SETFL, O_NONBLOCK);
+	fcntl(fileFds[STDOUT_FILENO], F_SETFL, O_NONBLOCK);
+
 	write(fileFds[STDIN_FILENO], reinterpret_cast<char*> (&body[0]), body.size());
 	lseek(fileFds[STDIN_FILENO], 0, SEEK_SET);
 
 	pid = fork();
 	if (pid < 0) {
 		std::cerr << "Fork crashed." << std::endl;
-		result += "Status: ";
-		result += HTTP_INTERNAL_SERVER_ERROR;
-		result += EMPTY_LINE;
-		return result;
+		tmpResult += "Status: ";
+		tmpResult += HTTP_INTERNAL_SERVER_ERROR;
+		tmpResult += EMPTY_LINE;
+		result_.insert(result_.end(), tmpResult.begin(), tmpResult.end());
+		return result_;
 	}
 
 	/* child process */	
@@ -109,17 +114,17 @@ std::string Cgi::execute() {
 		
 		/* if execve() failed */
 		std::cerr << "execute: CGI execve fail" << std::endl;		
-		result += "Status: ";
-		result += HTTP_INTERNAL_SERVER_ERROR;
-		result += EMPTY_LINE;
-		write(STDOUT_FILENO, result.c_str(), result.length());
+		tmpResult += "Status: ";
+		tmpResult += HTTP_INTERNAL_SERVER_ERROR;
+		tmpResult += EMPTY_LINE;
+		write(STDOUT_FILENO, tmpResult.c_str(), tmpResult.length());
 	} else {
 		waitpid(pid, NULL, 0);
 		lseek(fileFds[STDOUT_FILENO], 0, SEEK_SET);
 		while (ret > 0) {
 			memset(readBuf, 0, CGI_BUF_SIZE);
 			ret = read(fileFds[STDOUT_FILENO], readBuf, CGI_BUF_SIZE - 1);
-			result += readBuf;
+			result_.insert(result_.end(), readBuf, readBuf + ret);
 		}
 	}
 
@@ -134,5 +139,6 @@ std::string Cgi::execute() {
 	close(tmpStd[STDIN_FILENO]);
 	close(tmpStd[STDOUT_FILENO]);
 
-	return (result);
+	timestampNoSocket("cgi execute end", start);
+	return (result_);
 }

--- a/srcs/Cgi.cpp
+++ b/srcs/Cgi.cpp
@@ -1,5 +1,7 @@
 #include "Cgi.hpp"
 
+extern timeval start;
+
 Cgi::Cgi() {}
 
 Cgi::Cgi(Request *request)

--- a/srcs/Cgi.hpp
+++ b/srcs/Cgi.hpp
@@ -19,6 +19,7 @@ class Cgi {
 private:
 	Request						*request_;
 	std::vector<std::string>	env_;
+	std::vector<char>			result_;
 
 	void	setEnv();
 	char	**getEnv();
@@ -29,7 +30,7 @@ public:
 	Cgi(Request *request);
 	~Cgi();
 
-	std::string	execute();
+	const std::vector<char>	&execute();
 };
 
 #endif

--- a/srcs/Nginxs.cpp
+++ b/srcs/Nginxs.cpp
@@ -39,7 +39,9 @@ void	Nginxs::run() {
 		pollfds_[fds].fd = -1;
 
 	while (1) {
-		ret = poll(pollfds_, POLLFDSLEN, 5000);
+		ret = poll(pollfds_, POLLFDSLEN, 1000);
+		if (ret == 0)
+			continue ;
 		if (ret == -1) {
 			for (int fds = 0; fds < POLLFDSLEN; fds++) {
 				if (pollfds_[fds].fd != -1)

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -1,5 +1,7 @@
 #include "Request.hpp"
 
+extern timeval start;
+
 Request::Request()
 	: uri_(nullptr), bodyLength_(0), isChunkSize_(FT_TRUE) {}
 
@@ -141,6 +143,7 @@ void	Request::parseChunkedBody() {
 	std::string					chunkSizeString;
 	std::size_t					chunkSize;
 
+	// timestamp("parseChunkedBody start", start);
 	it = std::search(originalBody_.begin(), originalBody_.end(), crlf, crlf + strlen(crlf));
 	while (it != originalBody_.end()) {
 		if (isChunkSize_) {
@@ -158,4 +161,5 @@ void	Request::parseChunkedBody() {
 		isChunkSize_ = !isChunkSize_; // toggle: chunk size or chunk data
 		it = std::search(originalBody_.begin(), originalBody_.end(), crlf, crlf + strlen(crlf));
 	}
+	// timestamp("parseChunkedBody end", start);
 }

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -9,8 +9,8 @@ Request::~Request() {
 	delete uri_;
 }
 
-void Request::appendBody(const std::vector<char> &vec) {
-	body_.insert(body_.end(), vec.begin(), vec.end());
+void Request::appendBody(const std::vector<char>::iterator &startIt, const std::vector<char>::iterator &endIt) {
+	body_.insert(body_.end(), startIt, endIt);
 }
 
 void	Request::parseHeader(const std::vector<std::string> &splitedMessage) {
@@ -143,7 +143,7 @@ void	Request::parseChunkedBody() {
 	std::string					chunkSizeString;
 	std::size_t					chunkSize;
 
-	// timestamp("parseChunkedBody start", start);
+	// timestamp("* parseChunkedBody start", start);
 	it = std::search(originalBody_.begin(), originalBody_.end(), crlf, crlf + strlen(crlf));
 	while (it != originalBody_.end()) {
 		if (isChunkSize_) {
@@ -155,11 +155,11 @@ void	Request::parseChunkedBody() {
 			addBodyLength(chunkSize);
 		} else {
 			// is chunk data
-			appendBody(std::vector<char>(originalBody_.begin(), it));
+			appendBody(originalBody_.begin(), it);
 		}
-		originalBody_ = std::vector<char>(it + strlen(crlf), originalBody_.end());
+		originalBody_.assign(it + strlen(crlf), originalBody_.end());
 		isChunkSize_ = !isChunkSize_; // toggle: chunk size or chunk data
 		it = std::search(originalBody_.begin(), originalBody_.end(), crlf, crlf + strlen(crlf));
 	}
-	// timestamp("parseChunkedBody end", start);
+	// timestamp("* parseChunkedBody end", start);
 }

--- a/srcs/Request.cpp
+++ b/srcs/Request.cpp
@@ -14,8 +14,8 @@ void Request::appendBody(const std::vector<char>::iterator &startIt, const std::
 }
 
 void	Request::parseHeader(const std::vector<std::string> &splitedMessage) {
-	std::vector<const std::string>::iterator	iter = splitedMessage.begin();
-	std::vector<std::string> splitedRequstLine = split(*iter, " ");
+	std::vector<std::string>::const_iterator	it = splitedMessage.begin();
+	std::vector<std::string> splitedRequstLine = split(*it, " ");
 	std::vector<std::string> splitedHeaderLine;
 
 	// request line
@@ -24,13 +24,13 @@ void	Request::parseHeader(const std::vector<std::string> &splitedMessage) {
 	method_ = splitedRequstLine[0];
 	uri_ = new Uri(splitedRequstLine[1]);
 	version_ = splitedRequstLine[2];
-	iter++;
+	it++;
 	// headers
-	while (iter != splitedMessage.end()) {
-		splitedHeaderLine = split(*iter, ": ");
+	while (it != splitedMessage.end()) {
+		splitedHeaderLine = split(*it, ": ");
 		std::transform(splitedHeaderLine[0].begin(), splitedHeaderLine[0].end(), splitedHeaderLine[0].begin(), ::tolower);
 		headers_.insert(std::pair<std::string, std::string>(splitedHeaderLine[0], splitedHeaderLine[1]));
-		iter++;
+		it++;
 	}
 }
 
@@ -55,7 +55,7 @@ const std::map<std::string, std::string> &Request::getHeaders() {
 	return headers_;
 }
 
-const std::string Request::getHeaderValue(std::string fieldName) {
+const std::string Request::getHeaderValue(const std::string &fieldName) {
 	std::map<std::string, std::string>::iterator it = headers_.find(fieldName);
 	if (it == headers_.end())
 		return std::string("");
@@ -93,16 +93,16 @@ void Request::setLocationBlock(const Block &locationBlock) {
 
 void	Request::setBody() {
 	if (getHeaderValue("transfer-encoding") != "chunked")
-		body_ = std::vector<char>(originalBody_.begin(), originalBody_.begin() + getContentLengthNumber());
+		body_.assign(originalBody_.begin(), originalBody_.begin() + getContentLengthNumber());
 }
 
 void Request::setHeaders() {
-	std::vector<std::string>						splitedMessage;
-	std::map<std::string, std::string>::iterator	iter;
+	std::vector<std::string>	splitedMessage;
 
 	splitedMessage = split(std::string(originalHeader_.begin(), originalHeader_.end()), CRLF);
 	parseHeader(splitedMessage);
 
+	// std::map<std::string, std::string>::iterator	iter;
 	// for (iter = headers_.begin(); iter != headers_.end(); iter++)
 	// 	std::cout << iter->first << " | " << iter->second << std::endl;
 }
@@ -111,12 +111,12 @@ void Request::setFilePath() {
 	filePath_ = uri_->getFilePath();
 }
 
-void Request::setOriginalHeader(const std::vector<char> originalHeader) {
-	originalHeader_ = originalHeader;
+void Request::setOriginalHeader(const std::vector<char>::iterator &startIt, const std::vector<char>::iterator &endIt) {
+	originalHeader_.assign(startIt, endIt);
 }
 
-void	Request::setOriginalBody(const std::vector<char> originalBody) {
-	originalBody_ = originalBody;
+void	Request::setOriginalBody(const std::vector<char>::iterator &startIt, const std::vector<char>::iterator &endIt) {
+	originalBody_.assign(startIt, endIt);
 }
 
 void Request::setBodyLength(const std::size_t bodyLength) {
@@ -137,9 +137,7 @@ void Request::addBodyLength(const std::size_t length) {
 
 void	Request::parseChunkedBody() {
 	const char 					*crlf = "\r\n";
-	std::vector<char>			splitedBody;
 	std::vector<char>::iterator it;
-	std::vector<char>::iterator it2;
 	std::string					chunkSizeString;
 	std::size_t					chunkSize;
 

--- a/srcs/Request.hpp
+++ b/srcs/Request.hpp
@@ -28,7 +28,7 @@ private:
 	std::size_t							bodyLength_;
 	ft_bool								isChunkSize_; // or chunk data
 
-	void								appendBody(const std::vector<char> &vec);
+	void								appendBody(const std::vector<char>::iterator &startIt, const std::vector<char>::iterator &endIt);
 
 	void	parseHeader(const std::vector<std::string> &splitedMessage);
 

--- a/srcs/Request.hpp
+++ b/srcs/Request.hpp
@@ -41,7 +41,7 @@ public:
 	const Uri									*getUri();
 	const std::string							&getVersion();
 	const std::map<std::string, std::string>	&getHeaders();
-	const std::string							getHeaderValue(std::string fieldName);
+	const std::string							getHeaderValue(const std::string &fieldName);
 	const std::vector<char>						&getBody();
 	const std::string							&getFilePath();
 	const std::vector<char>						&getOriginalHeader();
@@ -53,8 +53,8 @@ public:
 	void	setBody();
 	void	setHeaders();
 	void	setFilePath();
-	void	setOriginalHeader(const std::vector<char> originalHeader);
-	void	setOriginalBody(const std::vector<char> originalBody);
+	void	setOriginalHeader(const std::vector<char>::iterator &startIt, const std::vector<char>::iterator &endIt);
+	void	setOriginalBody(const std::vector<char>::iterator &startIt, const std::vector<char>::iterator &endIt);
 	void	setLocationBlock(const Block &locationBlock);
 	void	setBodyLength(const std::size_t bodyLength);
 

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -19,10 +19,10 @@ Response::Response(std::string status, const std::vector<char> &result, ft_bool 
 	if (isCgi) {
 		it = std::search(result.begin(), result.end(), crlf, crlf + strlen(crlf));
 		if (it != result.end()) {
-			body_ = std::vector<char>(it + strlen(crlf), result.end());
+			body_.assign(it + strlen(crlf), result.end());
 			cgiHeaders = std::string(result.begin(), it);
 			// std::cout << "cgiHeaders: " << cgiHeaders << std::endl;
-			splitedHeaders = split(std::string(cgiHeaders.begin(), cgiHeaders.end()), "\r\n");
+			splitedHeaders = split(cgiHeaders, "\r\n");
 			for (it_s = splitedHeaders.begin(); it_s != splitedHeaders.end(); it_s++) {
 				splitedHeaderLine = split(*it_s, ": ");
 				std::transform(splitedHeaderLine[0].begin(), splitedHeaderLine[0].end(), splitedHeaderLine[0].begin(), ::tolower);

--- a/srcs/Response.cpp
+++ b/srcs/Response.cpp
@@ -1,18 +1,17 @@
 #include "Response.hpp"
 
-Response::Response(std::string status) {
+Response::Response(const std::string &status) {
 	statusLine_ = "HTTP/1.1 " + status;
 	makeDefaultHeaders();
 }
 
-Response::Response(std::string status, const std::vector<char> &result, ft_bool isCgi) {
-	// Set cgi headers
+Response::Response(const std::string &status, const std::vector<char> &result, ft_bool isCgi) {
 	std::vector<char>::const_iterator	it;
 	const char 							*crlf = "\r\n\r\n";
 	std::string 						cgiHeaders;
 	std::vector<std::string>			splitedHeaders;
 	std::vector<std::string>			splitedHeaderLine;
-	std::vector<std::string>::iterator	it_s;
+	std::vector<std::string>::iterator	sIt;
 
 	statusLine_ = "HTTP/1.1 " + status;
 	body_ = result;
@@ -21,10 +20,9 @@ Response::Response(std::string status, const std::vector<char> &result, ft_bool 
 		if (it != result.end()) {
 			body_.assign(it + strlen(crlf), result.end());
 			cgiHeaders = std::string(result.begin(), it);
-			// std::cout << "cgiHeaders: " << cgiHeaders << std::endl;
 			splitedHeaders = split(cgiHeaders, "\r\n");
-			for (it_s = splitedHeaders.begin(); it_s != splitedHeaders.end(); it_s++) {
-				splitedHeaderLine = split(*it_s, ": ");
+			for (sIt = splitedHeaders.begin(); sIt != splitedHeaders.end(); sIt++) {
+				splitedHeaderLine = split(*sIt, ": ");
 				std::transform(splitedHeaderLine[0].begin(), splitedHeaderLine[0].end(), splitedHeaderLine[0].begin(), ::tolower);
 				if (splitedHeaderLine[0] == "status") {
 					statusLine_ = "HTTP/1.1 " + splitedHeaderLine[1];
@@ -60,33 +58,37 @@ void Response::makeDefaultHeaders() {
 		appendHeader("content-type", MIME_HTML);
 }
 
-const std::string Response::getHeaderValue(std::string fieldName) {
+const std::string Response::getHeaderValue(const std::string &fieldName) {
 	std::map<std::string, std::string>::iterator it = headers_.find(fieldName);
 	if (it == headers_.end())
 		return std::string("");
 	return it->second;
 }
 
-std::vector<char>	Response::createMessage() {
-	std::vector<char>								message;
+const std::vector<char>	&Response::createMessage() {
 	std::map<std::string, std::string>::iterator	it;
 	const char 										*crlf = CRLF;
 	const char 										*headerDelim = ": ";
 
-	message.insert(message.end(), statusLine_.begin(), statusLine_.end());
-	message.insert(message.end(), crlf, crlf + strlen(crlf));
+	// status line
+	message_.insert(message_.end(), statusLine_.begin(), statusLine_.end());
+
+	// header
+	message_.insert(message_.end(), crlf, crlf + strlen(crlf));
 	for (it = headers_.begin(); it != headers_.end(); it++) {
-		message.insert(message.end(), it->first.begin(), it->first.end());
-		message.insert(message.end(), headerDelim, headerDelim + strlen(headerDelim));
-		message.insert(message.end(), it->second.begin(), it->second.end());
-		message.insert(message.end(), crlf, crlf + strlen(crlf));
+		message_.insert(message_.end(), it->first.begin(), it->first.end());
+		message_.insert(message_.end(), headerDelim, headerDelim + strlen(headerDelim));
+		message_.insert(message_.end(), it->second.begin(), it->second.end());
+		message_.insert(message_.end(), crlf, crlf + strlen(crlf));
 	}
-	message.insert(message.end(), crlf, crlf + strlen(crlf));
-	message.insert(message.end(), body_.begin(), body_.end());
-	return message;
+	message_.insert(message_.end(), crlf, crlf + strlen(crlf));
+
+	// body
+	message_.insert(message_.end(), body_.begin(), body_.end());
+	return message_;
 }
 
-void	Response::setContentType(std::string fileExtension) {
+void	Response::setContentType(const std::string &fileExtension) {
 	headers_.erase("content-type");
 	if (fileExtension == "html")
 		appendHeader("content-type", MIME_HTML);
@@ -116,6 +118,6 @@ void	Response::setContentType(std::string fileExtension) {
 		appendHeader("content-type", MIME_OCTET);
 }
 
-void	Response::appendHeader(std::string fieldName, std::string value) {
+void	Response::appendHeader(const std::string &fieldName, const std::string &value) {
 	headers_.insert(std::pair<std::string, std::string>(fieldName, value));
 }

--- a/srcs/Response.hpp
+++ b/srcs/Response.hpp
@@ -20,21 +20,22 @@ private:
 	std::string								statusLine_;
 	std::map<std::string, std::string>		headers_;
 	std::vector<char>						body_;
+	std::vector<char>						message_;
 
 	std::string makeDateValue();
 	void makeDefaultHeaders();
 
-	const std::string getHeaderValue(std::string fieldName);
+	const std::string getHeaderValue(const std::string &fieldName);
 
 public:
-	Response(std::string status);
-	Response(std::string status, const std::vector<char> &result, ft_bool isCgi = false);
+	Response(const std::string &status);
+	Response(const std::string &status, const std::vector<char> &result, ft_bool isCgi = false);
 	~Response();
 
-	std::vector<char>	createMessage();
+	const std::vector<char>	&createMessage();
 
-	void	setContentType(std::string fileExtension);
-	void	appendHeader(std::string fieldName, std::string value);
+	void	setContentType(const std::string &fileExtension);
+	void	appendHeader(const std::string &fieldName, const std::string &value);
 };
 
 #endif

--- a/srcs/Worker.cpp
+++ b/srcs/Worker.cpp
@@ -86,6 +86,7 @@ ft_bool Worker::work() {
 				return ret;
 		} else if (pollfd_->revents == POLLOUT && isRecvCompleted_ == FT_TRUE) {
 			timestamp("recv end: ", start);
+			std::cerr << "recv end connectsocket: " << connectSocket_ << std::endl;
 			timestamp("setBody start: ", start);
 			request_->setBody();
 			timestamp("setBody end: ", start);
@@ -138,6 +139,7 @@ ft_bool Worker::recv() {
 	buf[ret] = '\0';
 	if (isNewRequest_ == FT_TRUE) {
 		timestamp("recv start: ", start);
+		std::cerr << "recv start connectsocket: " << connectSocket_ << std::endl;
 		delete request_;
 		request_ = new Request();
 		isNewRequest_ = FT_FALSE;
@@ -281,7 +283,7 @@ ft_bool Worker::executePost() {
 		std::string result = cgi.execute();
 		timestamp("Cgi execute end: ", start);
 		timestamp("response make start: ", start);
-		Response response(HTTP_CREATED, stringToCharV(result), FT_TRUE);
+		Response response(HTTP_CREATED, stringToCharV(result), FT_TRUE);	// stringToCharV 오래 걸림 (1103635)
 		timestamp("response make end: ", start);
 		return send(response.createMessage());
 	}

--- a/srcs/Worker.hpp
+++ b/srcs/Worker.hpp
@@ -62,13 +62,13 @@ public:
 		int			httpCode_;
 
 	public:
-		HttpException(const std::string message, const std::string httpCode);
+		HttpException(const std::string &message, const std::string &httpCode);
 		~HttpException() throw();
 		virtual const char *what() const throw();
 
 		const std::string	&getHttpStatus();
 		int					getHttpCode();
-		std::vector<char>	makeErrorHtml(const std:: string &errorPage);
+		std::vector<char>	makeErrorHtml(const std::string &errorPage);
 	};
 };
 

--- a/srcs/Worker.hpp
+++ b/srcs/Worker.hpp
@@ -24,8 +24,6 @@
 #include "autoindex/Autoindex.hpp"
 #include "config/Block.hpp"
 
-#define BUFFER_LENGTH 5024000
-
 class Worker {
 private:
 	Block			serverBlock_;

--- a/srcs/config/Block.cpp
+++ b/srcs/config/Block.cpp
@@ -133,7 +133,7 @@ Block &Block::operator=(const Block &origin) {
 void Block::setDefaultBlock(const char *file) {
 	std::vector<std::string>	tokens;
 	int							tokenSize;
-	char						buffer[BUFFER_SIZE + 1];
+	char						buffer[CONFIG_BUF_SIZE + 1];
 	int							fd;
 	int							ret;
 	std::string					line = "";
@@ -142,11 +142,11 @@ void Block::setDefaultBlock(const char *file) {
 	fd = open(file, O_RDONLY);
 	if (fd <= 0)
 		throw std::runtime_error("fail: Opening configuration file\n");
-	ret = read(fd, buffer, BUFFER_SIZE);
+	ret = read(fd, buffer, CONFIG_BUF_SIZE);
 	while (ret > 0) {
 		buffer[ret] = '\0';
 		line += buffer;
-		ret = read(fd, buffer, BUFFER_SIZE);
+		ret = read(fd, buffer, CONFIG_BUF_SIZE);
 	}
 	if (ret == FT_ERROR) {
 		close(fd);

--- a/srcs/config/Config.cpp
+++ b/srcs/config/Config.cpp
@@ -1,7 +1,7 @@
 #include "Config.hpp"
 
 std::vector<std::string> Config::readAndSplit(const char *filePath) {
-	char						buffer[BUFFER_SIZE + 1];
+	char						buffer[CONFIG_BUF_SIZE + 1];
 	int							fd;
 	int							ret;
 	std::string					line = "";
@@ -11,7 +11,7 @@ std::vector<std::string> Config::readAndSplit(const char *filePath) {
 	fd = open(filePath, O_RDONLY);
 	if (fd <= 0)
 		throw std::runtime_error("fail: Opening configuration file\n");
-	ret = read(fd, buffer, BUFFER_SIZE);
+	ret = read(fd, buffer, CONFIG_BUF_SIZE);
 	if (ret == 0) {
 		serverBlocks_.push_back(Block::defaultBlock_);
 		return tokens;
@@ -19,7 +19,7 @@ std::vector<std::string> Config::readAndSplit(const char *filePath) {
 	while (ret > 0) {
 		buffer[ret] = '\0';
 		line += buffer;
-		ret = read(fd, buffer, BUFFER_SIZE);
+		ret = read(fd, buffer, CONFIG_BUF_SIZE);
 	}
 	if (ret == FT_ERROR) {
 		close(fd);

--- a/srcs/config/Config.hpp
+++ b/srcs/config/Config.hpp
@@ -1,8 +1,6 @@
 #ifndef __CONFIG_HPP__
 # define __CONFIG_HPP__
 
-# define BUFFER_SIZE 1600
-
 # include "Block.hpp"
 # include <unistd.h>
 # include <fcntl.h>

--- a/srcs/macro.hpp
+++ b/srcs/macro.hpp
@@ -36,4 +36,9 @@
 #define CGI_FILE_MODE		0644
 #define CGI_BUF_SIZE		65000
 
+#define RECV_BUF_SIZE 21504
+#define CONFIG_BUF_SIZE 1600
+
+#define ONE_SEC_IN_MICROSEC 1000000
+
 #endif

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -1,6 +1,10 @@
 #include "Nginxs.hpp"
 
+timeval start;
+
 int	main(int argc, char **argv) {
+	gettimeofday(&start, NULL);
+
 	if (argc != 2) {
 		std::cout << "Usage: ./webserv [CONF FILE NAME]" << std::endl;
 		return EXIT_FAILURE;

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -110,7 +110,15 @@ ft_bool hasWordInCharV(const std::vector<char> &src, const char *word) {
 	std::vector<char>::const_iterator it;
 
 	it = std::search(src.begin(), src.end(), word, word + strlen(word));
+	
 	if (it == src.end())
 		return FT_FALSE;
 	return FT_TRUE;
+}
+
+void timestamp(const std::string &msg, timeval start) {
+	timeval	now;
+
+	gettimeofday(&now, NULL);
+	std::cerr << msg << ": " << (now.tv_sec - start.tv_sec) * ONE_SEC_IN_MICROSEC + (now.tv_usec - start.tv_usec) << std::endl;
 }

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -93,7 +93,7 @@ std::string createPaddedString(int width, const std::string &str) {
 	return createPadding(width, str.length()) + str;
 }
 
-size_t	hexStringToNumber(std::string s) {
+size_t	hexStringToNumber(const std::string &s) {
 	size_t				n;
 	std::stringstream	ss;
 
@@ -102,7 +102,7 @@ size_t	hexStringToNumber(std::string s) {
 	return n;
 }
 
-std::vector<char> stringToCharV(std::string s) {
+std::vector<char> stringToCharV(const std::string &s) {
 	return std::vector<char>(s.begin(), s.end());
 }
 
@@ -116,9 +116,16 @@ ft_bool hasWordInCharV(const std::vector<char> &src, const char *word) {
 	return FT_TRUE;
 }
 
-void timestamp(const std::string &msg, timeval start) {
+void timestamp(const std::string &msg, timeval start, int socketId) {
 	timeval	now;
 
 	gettimeofday(&now, NULL);
-	std::cerr << msg << ": " << (now.tv_sec - start.tv_sec) * ONE_SEC_IN_MICROSEC + (now.tv_usec - start.tv_usec) << std::endl;
+	std::cerr <<  "(" << socketId << ") \t\t" << (now.tv_sec - start.tv_sec) * ONE_SEC_IN_MICROSEC + (now.tv_usec - start.tv_usec) << " :\t\t" << msg << std::endl;
+}
+
+void timestampNoSocket(const std::string &msg, timeval start) {
+	timeval	now;
+
+	gettimeofday(&now, NULL);
+	std::cerr << (now.tv_sec - start.tv_sec) * ONE_SEC_IN_MICROSEC + (now.tv_usec - start.tv_usec) << " :\t\t" << msg << std::endl;
 }

--- a/srcs/utils.hpp
+++ b/srcs/utils.hpp
@@ -31,9 +31,10 @@ ft_bool						isIncluded(const std::string &value, const std::vector<std::string>
 ft_bool						isDirectory(const std::string &filePath);
 std::string					createPadding(int width, int length);
 std::string					createPaddedString(int width, const std::string &str);
-size_t						hexStringToNumber(std::string s);
-std::vector<char>			stringToCharV(std::string s);
+size_t						hexStringToNumber(const std::string &s);
+std::vector<char>			stringToCharV(const std::string &s);
 ft_bool						hasWordInCharV(const std::vector<char> &src, const char *word);
-void						timestamp(const std::string &msg, timeval from);
+void						timestamp(const std::string &msg, timeval from, int socketId);
+void						timestampNoSocket(const std::string &msg, timeval start);
 
 #endif

--- a/srcs/utils.hpp
+++ b/srcs/utils.hpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <set>
 #include <algorithm>
+#include <sys/time.h>
 #include "macro.hpp"
 
 template <typename T>
@@ -33,5 +34,6 @@ std::string					createPaddedString(int width, const std::string &str);
 size_t						hexStringToNumber(std::string s);
 std::vector<char>			stringToCharV(std::string s);
 ft_bool						hasWordInCharV(const std::vector<char> &src, const char *word);
+void						timestamp(const std::string &msg, timeval from);
 
 #endif


### PR DESCRIPTION
## 작업 내용
- closes #64 

## 리뷰어에게
- 로직 상 새로운 인스턴스(특히 `vector<char>`)를 생성하는 비용이 크다는 것을 발견하고 시간이 오래 걸리는 두 함수에서 필요없는 부분을 리팩토링하였습니다.
  - 최대한 새 인스턴스를 만들지 않고 포인터나 참조자를 활용한다면 시간이 많이 줄어들 것으로 보입니다.
  - 비슷한 코드가 있는 부분을 모두 찾아서 리팩토링하지는 않았는데, 추후 여유가 있으면 해보아도 괜찮을 것 같습니다.
- 실험 결과는 노션에 정리해두었으며, 마지막 테스트의 총 소요 시간이 **17분**으로 줄었습니다.

😁 recv()가 시작하고 끝날 때 해당하는 소켓의 fd를 출력해보았더니 짝이 맞지 않는 것으로 보아 멀티플렉싱은 잘 동작하고 있는 것으로 보입니다.